### PR TITLE
fix: go installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ sudo snap install pwdsafety
 ### Go1.17+
 
 ```console
-go install -v github.com/edoardottt/pwdsafety@latest
+go install -v github.com/edoardottt/pwdsafety/cmd/pwdsafety@latest
 ```
 
 ### From source


### PR DESCRIPTION
Dead simple update for the installation command in the README to avoid getting this error
```
go: github.com/edoardottt/pwdsafety@latest: module github.com/edoardottt/pwdsafety@latest found (v0.4.0), but does not contain package github.com/edoardottt/pwdsafety
```
